### PR TITLE
add KV transaction interfaces and new transaction wrapping key-value store

### DIFF
--- a/storage/kv/bucket.go
+++ b/storage/kv/bucket.go
@@ -33,6 +33,3 @@ type CRUDBucket interface {
 	ROBucket
 	RWBucket
 }
-
-// Bucket is an alias for any commonly used key-value store.
-type Bucket = CRUDBucket

--- a/storage/kv/keys.go
+++ b/storage/kv/keys.go
@@ -33,3 +33,6 @@ type KeysPrefixTraversingBucket interface {
 	KeysTraverser
 	KeysPrefixTraverser
 }
+
+// Bucket is an alias for any commonly used key-value store.
+type Bucket = KeysPrefixTraversingBucket

--- a/storage/kv/kvtxn/bucket.go
+++ b/storage/kv/kvtxn/bucket.go
@@ -1,0 +1,77 @@
+package kvtxn
+
+import (
+	"context"
+
+	"github.com/micromdm/nanolib/storage/kv"
+)
+
+// Get retrieves value at key.
+// A previously staged key may be returned.
+func (b *KVTxn) Get(ctx context.Context, key string) ([]byte, error) {
+	if !b.hasOp(key) {
+		b.keyLock.RLock(key)
+		defer b.keyLock.RUnlock(key)
+	}
+	if !b.autoCommit {
+		b.stageLock.RLock()
+		defer b.stageLock.RUnlock()
+		if value, del, found := b.stageGet(key); found {
+			if del {
+				// found a stage operation that deleted this key
+				return nil, kv.ErrKeyNotFound
+			}
+			return value, nil
+		}
+	}
+	// fallback to underlying store
+	return b.store.Get(ctx, key)
+}
+
+// Set sets key to value in the staged operations.
+// This change may be auto-commited.
+func (b *KVTxn) Set(ctx context.Context, key string, value []byte) error {
+	if !b.hasOp(key) {
+		b.keyLock.Lock(key)
+	}
+	b.stageLock.Lock()
+	defer b.stageLock.Unlock()
+	b.stageSet(key, value)
+	if b.autoCommit {
+		return b.stageCommit(ctx)
+	}
+	return nil
+}
+
+// Has checks that key can be found.
+// A previously staged key may be returned.
+func (b *KVTxn) Has(ctx context.Context, key string) (bool, error) {
+	if !b.hasOp(key) {
+		b.keyLock.RLock(key)
+		defer b.keyLock.RUnlock(key)
+	}
+	if !b.autoCommit {
+		b.stageLock.RLock()
+		defer b.stageLock.RUnlock()
+		if has, found := b.stageHas(key); found {
+			return has, nil
+		}
+	}
+	// fallback to underlying store
+	return b.store.Has(ctx, key)
+}
+
+// Delete deletes key in the staged operations.
+// This change may be auto-commited.
+func (b *KVTxn) Delete(ctx context.Context, key string) error {
+	if !b.hasOp(key) {
+		b.keyLock.Lock(key)
+	}
+	b.stageLock.Lock()
+	defer b.stageLock.Unlock()
+	b.stageDelete(key)
+	if b.autoCommit {
+		return b.stageCommit(ctx)
+	}
+	return nil
+}

--- a/storage/kv/kvtxn/keys.go
+++ b/storage/kv/kvtxn/keys.go
@@ -1,0 +1,69 @@
+package kvtxn
+
+import (
+	"context"
+)
+
+// Keys returns all keys in the underlying key-value store merging with the operations stage.
+// The returned keys have no ordering guaratees.
+// The keys channel should be closed if cancel was provided and closed.
+// Beware of deadlocks with underlying implementations.
+// Note that key-based stage locks are not consulted.
+func (b *KVTxn) Keys(ctx context.Context, cancel <-chan struct{}) <-chan string {
+	return b.keysWithStagedKeys(b.store.Keys(ctx, cancel), cancel)
+}
+
+// Keys returns all keys starting with prefix in the underlying key-value store merging with the operations stage.
+// The returned keys have no ordering guaratees.
+// The keys channel should be closed if cancel was provided and closed.
+// Beware of deadlocks with underlying implementations.
+// Note that key-based stage locks are not consulted.
+func (b *KVTxn) KeysPrefix(ctx context.Context, prefix string, cancel <-chan struct{}) <-chan string {
+	return b.keysWithStagedKeys(b.store.KeysPrefix(ctx, prefix, cancel), cancel)
+}
+
+// stageKeys returns a slice of all staged keys.
+// Keys that have a delete operation are not included if noDel is true.
+func (b *KVTxn) stageKeys(skipDeleted bool) []string {
+	var r []string
+	for k, v := range b.stageKeyOps {
+		if v.del && skipDeleted {
+			continue
+		}
+		r = append(r, k)
+	}
+	return r
+}
+
+// keysWithStagedKeys returns a merged set from inKeys and keys from staged operations.
+func (b *KVTxn) keysWithStagedKeys(inKeys <-chan string, cancel <-chan struct{}) <-chan string {
+	r := make(chan string)
+	go func() {
+		defer close(r)
+		for k := range inKeys {
+			b.stageLock.RLock()
+			_, found := b.stageHas(k)
+			b.stageLock.RUnlock()
+			if found {
+				// skip this key, it's in the stage
+				continue
+			}
+			select {
+			case <-cancel:
+				return
+			case r <- k:
+			}
+		}
+		b.stageLock.RLock()
+		// retreive all of our staged keys (minus the staged deletions)
+		for _, k := range b.stageKeys(true) {
+			select {
+			case <-cancel:
+				return
+			case r <- k:
+			}
+		}
+		b.stageLock.RUnlock()
+	}()
+	return r
+}

--- a/storage/kv/kvtxn/kvtxn.go
+++ b/storage/kv/kvtxn/kvtxn.go
@@ -1,0 +1,127 @@
+// Package kvtxn provides an in-memory transactional wrapper for KV stores.
+// Note that underlying KV stores are assumed to not support
+// multi-operation atomicity. Thus this wrapper cannot guarantee
+// transaction atomicity, either.
+package kvtxn
+
+import (
+	"context"
+	"sync"
+
+	"github.com/micromdm/nanolib/storage/kv"
+)
+
+// KeyLockManager works like sync.RWMutex but supports per-key locking.
+type KeyLockManager interface {
+	RLock(key string)
+	RUnlock(key string)
+	Lock(key string)
+	Unlock(key string)
+}
+
+// keyOp is a staged operation for a key.
+type keyOp struct {
+	value []byte
+	del   bool // if true this operation signifies a deletion (of a key)
+}
+
+// KVTxn is a key-value store wrapper that supports in-memory transactions.
+// Note the underlying KV store can still be inconsistent—this wrapper
+// does NOT gauarantee any commit atomicity.
+//
+// KVTxn maintains an in-memory "stage" for write operations
+// per-transaction. These staged operations can be rolled-back or
+// committed.
+// The store uses key-based mutexes for the duration of transactions
+// to try to maintain consistency.
+type KVTxn struct {
+	store       kv.KeysPrefixTraversingBucket
+	stageLock   sync.RWMutex
+	stageKeyOps map[string]keyOp
+	keyLock     KeyLockManager
+	autoCommit  bool
+}
+
+// New creates a new in-memory transacting key-value store that wraps store.
+// Note that a single in-memory lock manager is created so transaction
+// locking will only be scoped to this newly created store.
+func New(store kv.KeysPrefixTraversingBucket) *KVTxn {
+	// create a new store with auto-commit on.
+	return new(store, NewInmemLockManager(), true)
+}
+
+// new is a helper for creating KVTxns that wraps store.
+func new(store kv.KeysPrefixTraversingBucket, keyLock KeyLockManager, autoCommit bool) *KVTxn {
+	if store == nil {
+		panic("nil store")
+	}
+	if keyLock == nil {
+		panic("nil key lock manager")
+	}
+	return &KVTxn{
+		store:       store,
+		stageKeyOps: make(map[string]keyOp),
+		keyLock:     keyLock,
+		autoCommit:  autoCommit,
+	}
+}
+
+// stageGet retreives a key from the staged key operations.
+func (b *KVTxn) stageGet(key string) (value []byte, del bool, found bool) {
+	keyOp, ok := b.stageKeyOps[key]
+	return keyOp.value, keyOp.del, ok
+}
+
+// stageSet sets a value for key in the staged key operations.
+func (b *KVTxn) stageSet(key string, value []byte) {
+	b.stageKeyOps[key] = keyOp{value: value}
+}
+
+// stageHas checks that a key can be found in the staged key operations.
+func (b *KVTxn) stageHas(key string) (has, found bool) {
+	keyOp, ok := b.stageKeyOps[key]
+	return !keyOp.del, ok
+}
+
+// stageDelete stages a key deletion in the staged key operations.
+func (b *KVTxn) stageDelete(key string) {
+	b.stageKeyOps[key] = keyOp{del: true}
+}
+
+// stageReset resets the staged operations.
+func (b *KVTxn) stageReset() {
+	for k := range b.stageKeyOps {
+		// make sure we unlock any keys in the stage
+		b.keyLock.Unlock(k)
+	}
+	b.stageKeyOps = make(map[string]keyOp)
+}
+
+// hasOp checks if there is an operation staged for key.
+// A read lock is obtained for the stage lookup.
+func (b *KVTxn) hasOp(key string) (ok bool) {
+	b.stageLock.RLock()
+	_, ok = b.stageKeyOps[key]
+	b.stageLock.RUnlock()
+	return
+}
+
+// stageCommit commits (sends) the staged operations to the wrapped KV store.
+func (b *KVTxn) stageCommit(ctx context.Context) error {
+	var err error
+	for key, op := range b.stageKeyOps {
+		if err == nil {
+			if op.del {
+				err = b.store.Delete(ctx, key)
+			} else {
+				err = b.store.Set(ctx, key, op.value)
+			}
+		}
+		b.keyLock.Unlock(key)
+		// if we had no error, remove the operation
+		if err == nil {
+			delete(b.stageKeyOps, key)
+		}
+	}
+	return err
+}

--- a/storage/kv/kvtxn/kvtxn_test.go
+++ b/storage/kv/kvtxn/kvtxn_test.go
@@ -1,0 +1,69 @@
+package kvtxn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/micromdm/nanolib/storage/kv"
+	"github.com/micromdm/nanolib/storage/kv/kvmap"
+	"github.com/micromdm/nanolib/storage/kv/test"
+)
+
+func TestKVTxn(t *testing.T) {
+	b := New(kvmap.New())
+	ctx := context.Background()
+	test.TestBucketSimple(t, ctx, b)
+	test.TestKeysTraversing(t, ctx, b)
+	test.TestTxnSimple(t, ctx, b)
+}
+
+func slicesEqual[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestKVTxnKeys(t *testing.T) {
+	u := kvmap.New()
+	b := New(u)
+	ctx := context.Background()
+	bt, err := b.BeginKeysPrefixTraversingBucketTxn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bt.Set(ctx, "hello", []byte("world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// make sure we have what we set in the txn
+	keys := kv.AllKeys(ctx, bt)
+	if want, have := []string{"hello"}, keys; !slicesEqual(want, have) {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+	// delete the key
+	err = bt.Delete(ctx, "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that we don't see it
+	keys = kv.AllKeys(ctx, bt)
+	if want, have := []string{}, keys; !slicesEqual(want, have) {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+	// set a value on the non-txn store (auto-commit)
+	err = u.Set(ctx, "hello", []byte("dlrow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// again check that our txn does not see it
+	keys = kv.AllKeys(ctx, bt)
+	if want, have := []string{}, keys; !slicesEqual(want, have) {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+}

--- a/storage/kv/kvtxn/kvtxn_test.go
+++ b/storage/kv/kvtxn/kvtxn_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/micromdm/nanolib/storage/kv"
 	"github.com/micromdm/nanolib/storage/kv/kvmap"
 	"github.com/micromdm/nanolib/storage/kv/test"
 )
@@ -15,55 +14,6 @@ func TestKVTxn(t *testing.T) {
 	test.TestBucketSimple(t, ctx, b)
 	test.TestKeysTraversing(t, ctx, b)
 	test.TestTxnSimple(t, ctx, b)
-}
-
-func slicesEqual[T comparable](a, b []T) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func TestKVTxnKeys(t *testing.T) {
-	u := kvmap.New()
-	b := New(u)
-	ctx := context.Background()
-	bt, err := b.BeginKeysPrefixTraversingBucketTxn(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = bt.Set(ctx, "hello", []byte("world"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// make sure we have what we set in the txn
-	keys := kv.AllKeys(ctx, bt)
-	if want, have := []string{"hello"}, keys; !slicesEqual(want, have) {
-		t.Errorf("want: %v, have: %v", want, have)
-	}
-	// delete the key
-	err = bt.Delete(ctx, "hello")
-	if err != nil {
-		t.Fatal(err)
-	}
-	// check that we don't see it
-	keys = kv.AllKeys(ctx, bt)
-	if want, have := []string{}, keys; !slicesEqual(want, have) {
-		t.Errorf("want: %v, have: %v", want, have)
-	}
-	// set a value on the non-txn store (auto-commit)
-	err = u.Set(ctx, "hello", []byte("dlrow"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// again check that our txn does not see it
-	keys = kv.AllKeys(ctx, bt)
-	if want, have := []string{}, keys; !slicesEqual(want, have) {
-		t.Errorf("want: %v, have: %v", want, have)
-	}
+	b = New(kvmap.New()) // clear test data
+	t.Run("TestKVTxnKeys", func(t *testing.T) { test.TestKVTxnKeys(t, ctx, b) })
 }

--- a/storage/kv/kvtxn/lockmgr.go
+++ b/storage/kv/kvtxn/lockmgr.go
@@ -1,0 +1,103 @@
+package kvtxn
+
+import (
+	"sync"
+)
+
+// InmemLockManager is a lock manager that supports locking on keys (strings).
+// In-memory native map based.
+type InmemLockManager struct {
+	locks    map[string]*sync.RWMutex
+	counters map[string]int
+	m        sync.Mutex
+}
+
+// NewInmemLockManager creates a new key lock manager.
+func NewInmemLockManager() *InmemLockManager {
+	return &InmemLockManager{
+		locks:    make(map[string]*sync.RWMutex),
+		counters: make(map[string]int),
+	}
+}
+
+// RLock locks key lock in klm for reading.
+// RLock on a sync.RWMutex is called under the hood.
+func (klm *InmemLockManager) RLock(key string) {
+	klm.m.Lock()
+
+	lock, ok := klm.locks[key]
+	if !ok || lock == nil {
+		lock = &sync.RWMutex{}
+		klm.locks[key] = lock
+	}
+
+	klm.counters[key]++
+
+	klm.m.Unlock()
+
+	lock.RLock()
+}
+
+// RUnlock undoes a single RLock call for key in klm.
+// RUnlock on a sync.RWMutex is called under the hood.
+func (klm *InmemLockManager) RUnlock(key string) {
+	klm.m.Lock()
+	defer klm.m.Unlock()
+
+	lock, ok := klm.locks[key]
+	if !ok || lock == nil {
+		// no lock present, remove the keys anyway
+		delete(klm.counters, key)
+		delete(klm.locks, key)
+		return
+	}
+
+	klm.counters[key]--
+	lock.RUnlock()
+
+	if klm.counters[key] <= 0 {
+		delete(klm.counters, key)
+		delete(klm.locks, key)
+	}
+}
+
+// Lock locks key for writing in klm.
+// Lock on a sync.RWMutex is called under the hood.
+func (klm *InmemLockManager) Lock(key string) {
+	klm.m.Lock()
+
+	lock, ok := klm.locks[key]
+	if !ok || lock == nil {
+		lock = &sync.RWMutex{}
+		klm.locks[key] = lock
+	}
+
+	klm.counters[key]++
+
+	klm.m.Unlock()
+
+	lock.Lock()
+}
+
+// Unlock unlocks key for writing in klm.
+// Unlock on a sync.RWMutex is called under the hood.
+func (klm *InmemLockManager) Unlock(key string) {
+	klm.m.Lock()
+	defer klm.m.Unlock()
+
+	lock, ok := klm.locks[key]
+	if !ok || lock == nil {
+		// no lock present, remove the keys anyway
+		delete(klm.counters, key)
+		delete(klm.locks, key)
+		return
+	}
+
+	klm.counters[key]--
+	lock.Unlock()
+
+	if klm.counters[key] <= 0 {
+		delete(klm.counters, key)
+		delete(klm.locks, key)
+	}
+}

--- a/storage/kv/kvtxn/lockmgr_test.go
+++ b/storage/kv/kvtxn/lockmgr_test.go
@@ -1,0 +1,60 @@
+package kvtxn
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestKeyLockManager(t *testing.T) {
+	timedKeyLockManagerTest(t, NewInmemLockManager())
+}
+
+func timedKeyLockManagerTest(t *testing.T, klm KeyLockManager) {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		klm.Lock("lock_key")
+
+		// signify we've completed locking
+		wg.Done()
+
+		time.Sleep(100 * time.Millisecond)
+
+		klm.Unlock("lock_key")
+	}()
+
+	// wait until we've completed locking
+	wg.Wait()
+
+	ch := make(chan struct{})
+	go func() {
+		klm.RLock("lock_key")
+
+		// signify that we've completed the lock
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+		t.Error("expected to be blocked, but returned early")
+	case <-time.After(50 * time.Millisecond):
+		// this timer should fire before the the first timer, above.
+		// which means the lock for the key should still be locked
+		// i.e. this case is expected behavior to exit the select
+	}
+
+	// wait until we're done with the second lock
+	<-ch
+
+	klm.RUnlock("lock_key")
+
+	select {
+	case <-ch:
+		//
+		// Expected behavior: we got through after unlock
+	default:
+		t.Error("expected second lock to have happened, but didn't")
+	}
+}

--- a/storage/kv/kvtxn/nop.go
+++ b/storage/kv/kvtxn/nop.go
@@ -1,0 +1,40 @@
+package kvtxn
+
+import (
+	"context"
+
+	"github.com/micromdm/nanolib/storage/kv"
+)
+
+// NopTxn wraps KV bucket storage to support transaction calls.
+// However it does not support transactions: KV storage calls are
+// passed directly through to the wrapped storage.
+// WARNING: this is dangerous.
+type NopTxn struct {
+	kv.KeysPrefixTraversingBucket
+}
+
+// NewNopTxn creates a new pass-through transaction wrapper.
+func NewNopTxn(b kv.KeysPrefixTraversingBucket) *NopTxn {
+	return &NopTxn{KeysPrefixTraversingBucket: b}
+}
+
+// BeginBucketTxn simply returns b.
+func (b *NopTxn) BeginBucketTxn(context.Context) (kv.BucketTxnCompleter, error) {
+	return b, nil
+}
+
+// BeginKeysPrefixTraversingBucketTxn simply returns b.
+func (b *NopTxn) BeginKeysPrefixTraversingBucketTxn(context.Context) (kv.KeysPrefixTraversingBucketTxnCompleter, error) {
+	return b, nil
+}
+
+// Commit does nothing.
+func (b *NopTxn) Commit(context.Context) error {
+	return nil
+}
+
+// Rollback does nothing.
+func (b *NopTxn) Rollback(context.Context) error {
+	return nil
+}

--- a/storage/kv/kvtxn/nop.go
+++ b/storage/kv/kvtxn/nop.go
@@ -19,13 +19,18 @@ func NewNopTxn(b kv.KeysPrefixTraversingBucket) *NopTxn {
 	return &NopTxn{KeysPrefixTraversingBucket: b}
 }
 
-// BeginBucketTxn simply returns b.
-func (b *NopTxn) BeginBucketTxn(context.Context) (kv.BucketTxnCompleter, error) {
+// BeginCRUDBucketTxn simply returns b.
+func (b *NopTxn) BeginCRUDBucketTxn(context.Context) (kv.CRUDBucketTxnCompleter, error) {
 	return b, nil
 }
 
 // BeginKeysPrefixTraversingBucketTxn simply returns b.
 func (b *NopTxn) BeginKeysPrefixTraversingBucketTxn(context.Context) (kv.KeysPrefixTraversingBucketTxnCompleter, error) {
+	return b, nil
+}
+
+// BeginBucketTxn simply returns b.
+func (b *NopTxn) BeginBucketTxn(context.Context) (kv.BucketTxnCompleter, error) {
 	return b, nil
 }
 

--- a/storage/kv/kvtxn/nop_test.go
+++ b/storage/kv/kvtxn/nop_test.go
@@ -1,0 +1,37 @@
+package kvtxn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/micromdm/nanolib/storage/kv/kvmap"
+	"github.com/micromdm/nanolib/storage/kv/test"
+)
+
+func TestNop(t *testing.T) {
+	ctx := context.Background()
+	b := NewNopTxn(kvmap.New())
+	bt, err := b.BeginBucketTxn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.TestBucketSimple(t, ctx, b)
+	test.TestKeysTraversing(t, ctx, b)
+
+	// We cannot run `test.TestTxnSimple()` because NopTxn does not
+	// actually support commit/rollback (i.e. caching transaction data)
+	// which is specifically tested for.
+	// test.TestTxnSimple(t, ctx, b)
+
+	// test just to make sure no error
+	err = bt.Commit(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test just to make sure no error
+	err = bt.Rollback(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/storage/kv/kvtxn/nop_test.go
+++ b/storage/kv/kvtxn/nop_test.go
@@ -11,7 +11,7 @@ import (
 func TestNop(t *testing.T) {
 	ctx := context.Background()
 	b := NewNopTxn(kvmap.New())
-	bt, err := b.BeginBucketTxn(ctx)
+	bt, err := b.BeginCRUDBucketTxn(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/kv/kvtxn/txn.go
+++ b/storage/kv/kvtxn/txn.go
@@ -31,13 +31,19 @@ func (b *KVTxn) Rollback(context.Context) error {
 	return nil
 }
 
-// KeysPrefixTraversingBucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
+// BeginKeysPrefixTraversingBucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
 // Auto-commit is turned off for the new store (allowing staged operations).
 func (b *KVTxn) BeginKeysPrefixTraversingBucketTxn(context.Context) (kv.KeysPrefixTraversingBucketTxnCompleter, error) {
 	return new(b.store, b.keyLock, false), nil
 }
 
-// BucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
+// BeginCRUDBucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
+// Auto-commit is turned off for the new store (allowing staged operations).
+func (b *KVTxn) BeginCRUDBucketTxn(context.Context) (kv.CRUDBucketTxnCompleter, error) {
+	return new(b.store, b.keyLock, false), nil
+}
+
+// BeginBucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
 // Auto-commit is turned off for the new store (allowing staged operations).
 func (b *KVTxn) BeginBucketTxn(context.Context) (kv.BucketTxnCompleter, error) {
 	return new(b.store, b.keyLock, false), nil

--- a/storage/kv/kvtxn/txn.go
+++ b/storage/kv/kvtxn/txn.go
@@ -1,0 +1,44 @@
+package kvtxn
+
+import (
+	"context"
+
+	"github.com/micromdm/nanolib/storage/kv"
+)
+
+// Commit sends the staged operations to the wrapped KV store.
+// Staged key write locks are unlocked.
+//
+// Note that this is a layer over a non-transactional KV store. Thus it
+// does not support "atomic" commits. Some staged operations may fail
+// and will return early leaving the underlying KV store in an
+// inconsistent state (e.g. with staged operations half-applied).
+// Note also that if there is an error then the stage will contain the
+// errored and remaining operations (which could theorectically be
+// re-tried with another commit attempt).
+func (b *KVTxn) Commit(ctx context.Context) error {
+	b.stageLock.Lock()
+	defer b.stageLock.Unlock()
+	return b.stageCommit(ctx)
+}
+
+// Rollback resets (removes) the staged operations and unlocks staged locks.
+func (b *KVTxn) Rollback(context.Context) error {
+	b.stageLock.Lock()
+	defer b.stageLock.Unlock()
+	// discard any transaction operations
+	b.stageReset()
+	return nil
+}
+
+// KeysPrefixTraversingBucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
+// Auto-commit is turned off for the new store (allowing staged operations).
+func (b *KVTxn) BeginKeysPrefixTraversingBucketTxn(context.Context) (kv.KeysPrefixTraversingBucketTxnCompleter, error) {
+	return new(b.store, b.keyLock, false), nil
+}
+
+// BucketTxn creates a new in-memory transacting key-value store that wraps the same store that b wraps.
+// Auto-commit is turned off for the new store (allowing staged operations).
+func (b *KVTxn) BeginBucketTxn(context.Context) (kv.BucketTxnCompleter, error) {
+	return new(b.store, b.keyLock, false), nil
+}

--- a/storage/kv/test/txn.go
+++ b/storage/kv/test/txn.go
@@ -1,0 +1,134 @@
+package test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/micromdm/nanolib/storage/kv"
+)
+
+func TestTxnSimple(t *testing.T, ctx context.Context, b kv.BucketTxnBucket) {
+	// first, set a value in the "parent" bucket
+	err := b.Set(ctx, "test-txn-key-1", []byte("test-txn-val-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sanity check by reading the value we just set
+	val, err := b.Get(ctx, "test-txn-key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := val, []byte("test-txn-val-1"); !bytes.Equal(have, want) {
+		t.Errorf("have: %v, want: %v", string(have), string(want))
+	}
+
+	// create a txn
+	bt, err := b.BeginBucketTxn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sanity check by reading the value we just set within the txn
+	val, err = bt.Get(ctx, "test-txn-key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := val, []byte("test-txn-val-1"); !bytes.Equal(have, want) {
+		t.Errorf("have: %v, want: %v", string(have), string(want))
+	}
+
+	// now, reset the key within the txn ...
+	err = bt.Set(ctx, "test-txn-key-1", []byte("test-txn-val-2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ... but rollback the transaction.
+	err = bt.Rollback(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// read the value we just reset in the parent and make sure it hasn't changed
+	val, err = b.Get(ctx, "test-txn-key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := val, []byte("test-txn-val-1"); !bytes.Equal(have, want) {
+		t.Errorf("have: %v, want: %v", string(have), string(want))
+	}
+
+	// read the value we just reset in the txn and make sure it was rolled back
+	val, err = bt.Get(ctx, "test-txn-key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := val, []byte("test-txn-val-1"); !bytes.Equal(have, want) {
+		t.Errorf("have: %v, want: %v", string(have), string(want))
+	}
+
+	// okay, let's re-reset the value again
+	err = bt.Set(ctx, "test-txn-key-1", []byte("test-txn-val-2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now, commit the change
+	err = bt.Commit(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// and make sure the "parent" bucket received that changed
+	val, err = b.Get(ctx, "test-txn-key-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if have, want := val, []byte("test-txn-val-2"); !bytes.Equal(have, want) {
+		t.Errorf("have: %v, want: %v", string(have), string(want))
+	}
+
+	// lets make a new txn
+	bt, err = b.BeginBucketTxn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// set a value
+	err = bt.Set(ctx, "test-txn-key-2", []byte("test-txn-val-3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sanity check by reading the value we just set in the within the txn
+	val, err = bt.Get(ctx, "test-txn-key-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if have, want := val, []byte("test-txn-val-3"); !bytes.Equal(have, want) {
+		t.Errorf("have: %v, want: %v", string(have), string(want))
+	}
+
+	// now, rollback our changes:
+	err = bt.Rollback(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// and try and read the values we just set (but discarded)
+	// should error with a key not found
+	_, err = bt.Get(ctx, "test-txn-key-2")
+	if !errors.Is(err, kv.ErrKeyNotFound) {
+		t.Fatal(err)
+	}
+
+	// .. same for the parent bucket
+	_, err = b.Get(ctx, "test-txn-key-2")
+	if !errors.Is(err, kv.ErrKeyNotFound) {
+		t.Fatal(err)
+	}
+}

--- a/storage/kv/test/txn.go
+++ b/storage/kv/test/txn.go
@@ -132,3 +132,55 @@ func TestTxnSimple(t *testing.T, ctx context.Context, b kv.BucketTxnBucket) {
 		t.Fatal(err)
 	}
 }
+
+func slicesEqual[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestKVTxnKeys(t *testing.T, ctx context.Context, b kv.KeysPrefixTraversingBucketTxnBucket) {
+	err := b.Set(ctx, "hello", []byte("dlrow"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bt, err := b.BeginKeysPrefixTraversingBucketTxn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bt.Set(ctx, "hello", []byte("world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// make sure we have what we set in the txn
+	keys := kv.AllKeys(ctx, bt)
+	if want, have := []string{"hello"}, keys; !slicesEqual(want, have) {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+	// delete the key
+	err = bt.Delete(ctx, "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that we don't see it
+	keys = kv.AllKeys(ctx, bt)
+	if want, have := []string{}, keys; !slicesEqual(want, have) {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+	// roll it back
+	err = bt.Rollback(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check that we don't see it in the parent store
+	keys = kv.AllKeys(ctx, b)
+	if want, have := []string{"hello"}, keys; !slicesEqual(want, have) {
+		t.Errorf("want: %v, have: %v", want, have)
+	}
+}

--- a/storage/kv/test/txn.go
+++ b/storage/kv/test/txn.go
@@ -9,7 +9,7 @@ import (
 	"github.com/micromdm/nanolib/storage/kv"
 )
 
-func TestTxnSimple(t *testing.T, ctx context.Context, b kv.BucketTxnBucket) {
+func TestTxnSimple(t *testing.T, ctx context.Context, b kv.TxnCRUDBucket) {
 	// first, set a value in the "parent" bucket
 	err := b.Set(ctx, "test-txn-key-1", []byte("test-txn-val-1"))
 	if err != nil {
@@ -26,7 +26,7 @@ func TestTxnSimple(t *testing.T, ctx context.Context, b kv.BucketTxnBucket) {
 	}
 
 	// create a txn
-	bt, err := b.BeginBucketTxn(ctx)
+	bt, err := b.BeginCRUDBucketTxn(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestTxnSimple(t *testing.T, ctx context.Context, b kv.BucketTxnBucket) {
 	}
 
 	// lets make a new txn
-	bt, err = b.BeginBucketTxn(ctx)
+	bt, err = b.BeginCRUDBucketTxn(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func slicesEqual[T comparable](a, b []T) bool {
 	return true
 }
 
-func TestKVTxnKeys(t *testing.T, ctx context.Context, b kv.KeysPrefixTraversingBucketTxnBucket) {
+func TestKVTxnKeys(t *testing.T, ctx context.Context, b kv.TxnKeysPrefixTraversingBucket) {
 	err := b.Set(ctx, "hello", []byte("dlrow"))
 	if err != nil {
 		t.Fatal(err)

--- a/storage/kv/txn.go
+++ b/storage/kv/txn.go
@@ -1,0 +1,51 @@
+package kv
+
+import "context"
+
+// TxnCompleter completes transactions; readying them for the next transaction.
+type TxnCompleter interface {
+	// Commit permanently applies the transaction's changes.
+	Commit(ctx context.Context) error
+
+	// Rollback discards the transaction's changes.
+	Rollback(ctx context.Context) error
+}
+
+// BucketTxnCompleter is a transacting key-value store.
+type BucketTxnCompleter interface {
+	Bucket
+	TxnCompleter
+}
+
+// BucketTxnBeginner can start transactions.
+type BucketTxnBeginner interface {
+	// Begin creates a new transaction that can later be completed.
+	BeginBucketTxn(ctx context.Context) (BucketTxnCompleter, error)
+}
+
+// BucketTxnBucket is a key-value store that can start transactions.
+// If a transaction has not begun then individual operations should auto-commit.
+type BucketTxnBucket interface {
+	BucketTxnBeginner
+	BucketTxnCompleter
+}
+
+// KeysPrefixTraversingBucketTxnCompleter is a transacting key-value store.
+// This store can traverse keys including using a prefix.
+type KeysPrefixTraversingBucketTxnCompleter interface {
+	KeysPrefixTraversingBucket
+	TxnCompleter
+}
+
+// KeysPrefixTraversingBucketTxnBeginner can start transactions.
+type KeysPrefixTraversingBucketTxnBeginner interface {
+	// Begin creates a new transaction that can later be completed.
+	BeginKeysPrefixTraversingBucketTxn(ctx context.Context) (KeysPrefixTraversingBucketTxnCompleter, error)
+}
+
+// KeysPrefixTraversingBucketTxnBucket is a key-value store that can start transactions.
+// If a transaction has not begun then individual operations should auto-commit.
+type KeysPrefixTraversingBucketTxnBucket interface {
+	KeysPrefixTraversingBucketTxnBeginner
+	KeysPrefixTraversingBucketTxnCompleter
+}

--- a/storage/kv/txn.go
+++ b/storage/kv/txn.go
@@ -2,32 +2,34 @@ package kv
 
 import "context"
 
-// TxnCompleter completes transactions; readying them for the next transaction.
+// TxnCompleter completes transactions.
 type TxnCompleter interface {
-	// Commit permanently applies the transaction's changes.
+	// Commit permanently applies transaction changes.
+	// Some implementations may not continue using the transaction.
 	Commit(ctx context.Context) error
 
-	// Rollback discards the transaction's changes.
+	// Rollback discards transaction changes.
+	// Some implementations may not continue using the transaction.
 	Rollback(ctx context.Context) error
 }
 
-// BucketTxnCompleter is a transacting key-value store.
-type BucketTxnCompleter interface {
-	Bucket
+// CRUDBucketTxnCompleter is a transacting key-value store.
+type CRUDBucketTxnCompleter interface {
+	CRUDBucket
 	TxnCompleter
 }
 
-// BucketTxnBeginner can start transactions.
-type BucketTxnBeginner interface {
-	// Begin creates a new transaction that can later be completed.
-	BeginBucketTxn(ctx context.Context) (BucketTxnCompleter, error)
+// CRUDBucketTxnBeginner can start transactions.
+type CRUDBucketTxnBeginner interface {
+	// BeginCRUDBucketTxn creates a new transaction that can later be completed.
+	BeginCRUDBucketTxn(ctx context.Context) (CRUDBucketTxnCompleter, error)
 }
 
 // BucketTxnBucket is a key-value store that can start transactions.
 // If a transaction has not begun then individual operations should auto-commit.
-type BucketTxnBucket interface {
-	BucketTxnBeginner
-	BucketTxnCompleter
+type TxnCRUDBucket interface {
+	CRUDBucketTxnBeginner
+	CRUDBucketTxnCompleter
 }
 
 // KeysPrefixTraversingBucketTxnCompleter is a transacting key-value store.
@@ -39,13 +41,32 @@ type KeysPrefixTraversingBucketTxnCompleter interface {
 
 // KeysPrefixTraversingBucketTxnBeginner can start transactions.
 type KeysPrefixTraversingBucketTxnBeginner interface {
-	// Begin creates a new transaction that can later be completed.
+	// BeginKeysPrefixTraversingBucketTxn creates a new transaction that can later be completed.
 	BeginKeysPrefixTraversingBucketTxn(ctx context.Context) (KeysPrefixTraversingBucketTxnCompleter, error)
 }
 
-// KeysPrefixTraversingBucketTxnBucket is a key-value store that can start transactions.
+// TxnKeysPrefixTraversingBucket is a key-value store that can start transactions.
 // If a transaction has not begun then individual operations should auto-commit.
-type KeysPrefixTraversingBucketTxnBucket interface {
+type TxnKeysPrefixTraversingBucket interface {
 	KeysPrefixTraversingBucketTxnBeginner
 	KeysPrefixTraversingBucketTxnCompleter
+}
+
+// BucketTxnCompleter is a transacting key-value store.
+type BucketTxnCompleter interface {
+	Bucket
+	TxnCompleter
+}
+
+// BucketTxnBeginner can start transactions.
+type BucketTxnBeginner interface {
+	// BeginBucketTxn creates a new transaction that can later be completed.
+	BeginBucketTxn(ctx context.Context) (BucketTxnCompleter, error)
+}
+
+// TxnBucket is a key-value store that can start transactions.
+// If a transaction has not begun then individual operations should auto-commit.
+type TxnBucket interface {
+	BucketTxnBeginner
+	BucketTxnCompleter
 }

--- a/storage/kv/txn_helpers.go
+++ b/storage/kv/txn_helpers.go
@@ -1,0 +1,54 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+)
+
+// BucketTxnPerformer is a function that executes KV operations within a transaction.
+type BucketTxnPerformer func(context.Context, Bucket) error
+
+// PerformBucketTxn calls f to execute KV operations within a transaction.
+// It takes care of beginning a transaction, committing it, or rolling
+// it back if f returns an error.
+func PerformBucketTxn(ctx context.Context, beginner BucketTxnBeginner, f BucketTxnPerformer) error {
+	// note: implementation same/similar to PerformKeysPrefixTraversingBucketTxn
+	b, err := beginner.BeginBucketTxn(ctx)
+	if err != nil {
+		return fmt.Errorf("txn begin: %w", err)
+	}
+	if err = f(ctx, b); err != nil {
+		if rbErr := b.Rollback(ctx); rbErr != nil {
+			return fmt.Errorf("txn rollback: %w; while trying to handle error: %v", rbErr, err)
+		}
+		return fmt.Errorf("txn rolled back: %w", err)
+	}
+	if err = b.Commit(ctx); err != nil {
+		return fmt.Errorf("txn commit: %w", err)
+	}
+	return nil
+}
+
+// KeysPrefixTraversingBucketTxnPerformer is a function that executes KV operations within a transaction.
+type KeysPrefixTraversingBucketTxnPerformer func(ctx context.Context, txn KeysPrefixTraversingBucket) error
+
+// PerformKeysPrefixTraversingBucketTxn calls f to execute KV operations within a transaction.
+// It takes care of beginning a transaction, committing it, or rolling
+// it back if f returns an error.
+func PerformKeysPrefixTraversingBucketTxn(ctx context.Context, beginner KeysPrefixTraversingBucketTxnBeginner, f KeysPrefixTraversingBucketTxnPerformer) error {
+	// note: implementation same/similar to PerformBucketTxn
+	b, err := beginner.BeginKeysPrefixTraversingBucketTxn(ctx)
+	if err != nil {
+		return fmt.Errorf("txn begin: %w", err)
+	}
+	if err = f(ctx, b); err != nil {
+		if rbErr := b.Rollback(ctx); rbErr != nil {
+			return fmt.Errorf("txn rollback: %w; while trying to handle error: %v", rbErr, err)
+		}
+		return fmt.Errorf("txn rolled back: %w", err)
+	}
+	if err = b.Commit(ctx); err != nil {
+		return fmt.Errorf("txn commit: %w", err)
+	}
+	return nil
+}

--- a/storage/kv/txn_helpers.go
+++ b/storage/kv/txn_helpers.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 )
 
-// BucketTxnPerformer is a function that executes KV operations within a transaction.
-type BucketTxnPerformer func(context.Context, Bucket) error
+// CRUDBucketTxnPerformer is a function that executes key-value operations within a transaction.
+type CRUDBucketTxnPerformer func(context.Context, CRUDBucket) error
 
-// PerformBucketTxn calls f to execute KV operations within a transaction.
+// PerformCRUDBucketTxn calls f to execute KV operations within a transaction.
 // It takes care of beginning a transaction, committing it, or rolling
 // it back if f returns an error.
-func PerformBucketTxn(ctx context.Context, beginner BucketTxnBeginner, f BucketTxnPerformer) error {
-	// note: implementation same/similar to PerformKeysPrefixTraversingBucketTxn
-	b, err := beginner.BeginBucketTxn(ctx)
+func PerformCRUDBucketTxn(ctx context.Context, beginner CRUDBucketTxnBeginner, f CRUDBucketTxnPerformer) error {
+	// note: implementation same/similar to PerformKeysPrefixTraversingBucketTxn and PerformBucketTxn
+	b, err := beginner.BeginCRUDBucketTxn(ctx)
 	if err != nil {
 		return fmt.Errorf("txn begin: %w", err)
 	}
@@ -36,8 +36,32 @@ type KeysPrefixTraversingBucketTxnPerformer func(ctx context.Context, txn KeysPr
 // It takes care of beginning a transaction, committing it, or rolling
 // it back if f returns an error.
 func PerformKeysPrefixTraversingBucketTxn(ctx context.Context, beginner KeysPrefixTraversingBucketTxnBeginner, f KeysPrefixTraversingBucketTxnPerformer) error {
-	// note: implementation same/similar to PerformBucketTxn
+	// note: implementation same/similar to PerformCRUDBucketTxn and PerformBucketTxn
 	b, err := beginner.BeginKeysPrefixTraversingBucketTxn(ctx)
+	if err != nil {
+		return fmt.Errorf("txn begin: %w", err)
+	}
+	if err = f(ctx, b); err != nil {
+		if rbErr := b.Rollback(ctx); rbErr != nil {
+			return fmt.Errorf("txn rollback: %w; while trying to handle error: %v", rbErr, err)
+		}
+		return fmt.Errorf("txn rolled back: %w", err)
+	}
+	if err = b.Commit(ctx); err != nil {
+		return fmt.Errorf("txn commit: %w", err)
+	}
+	return nil
+}
+
+// BucketTxnPerformer is a function that executes KV operations within a transaction.
+type BucketTxnPerformer func(ctx context.Context, txn Bucket) error
+
+// PerformBucketTxn calls f to execute KV operations within a transaction.
+// It takes care of beginning a transaction, committing it, or rolling
+// it back if f returns an error.
+func PerformBucketTxn(ctx context.Context, beginner BucketTxnBeginner, f BucketTxnPerformer) error {
+	// note: implementation same/similar to PerformCRUDBucketTxn and PerformKeysPrefixTraversingBucketTxn
+	b, err := beginner.BeginBucketTxn(ctx)
 	if err != nil {
 		return fmt.Errorf("txn begin: %w", err)
 	}


### PR DESCRIPTION
Add Go interfaces for beginning, committing, and rolling back transactions on key-value stores.

The included KV stores (`kvmap` and `kvdiskv`) do not support transactions. So we also add a KV store wrapper that supports in-memory staged-write non-atomic transactions with this PR. This allows us to wrap any existing KV store that may not support transactions to add *some* support. Unfortunately as it layers over non-transaction stores we can't actually guarantee atomicity for multiple staged write operations (that is: a transaction may end-up only being partially committed). Even so this allows us to get *some* of the benefit of transactions (largely discard/roll back support) but more importantly to use the same interfaces for real transaction-supporting KV stores that can plug into the interfaces.